### PR TITLE
Devops-781 Update release.yml to push docker image to public aws ecr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 env:
   IMAGE_REGISTRY: public.ecr.aws/emma
   IMAGE_NAME: emma-report-generator
+  IMAGE_TAG: 0.0.0-${{ inputs.sha || github.sha }}
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -40,14 +41,12 @@ jobs:
           registry-type: public
 
       - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        run: |
+          echo "Publish to docker registry"
+          docker buildx build --push \
+          --tag ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          --tag ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+          -f Dockerfile .
 
       - name: Post build info
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,9 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
-          aws-region: eu-central-1
-          registry-type: 'public'
+          registry-type: public
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
 name: Release Go project
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - '*'
+      - '!main'
 
+env:
+  IMAGE_REGISTRY: public.ecr.aws/emma
+  IMAGE_NAME: emma-report-generator
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -19,13 +26,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          region: ${{ secrets.AWS_REGION }}
-          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push Docker image
         id: build-and-push
@@ -34,10 +44,10 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY }}:${{ github.ref_name }}
-            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Post build info
         run: |
           echo "The Docker image has been built and pushed to the ECR repository."
-          echo "Image URL: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY }}:${{ github.ref_name }}"
+          echo "Image URL: ${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,13 @@
 name: Release Go project
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - '*'
-      - '!main'
+    tags:
+      - 'v*'
 
 env:
   IMAGE_REGISTRY: public.ecr.aws/emma
   IMAGE_NAME: emma-report-generator
-  IMAGE_TAG: 0.0.0-${{ inputs.sha || github.sha }}
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -45,7 +40,7 @@ jobs:
           echo "Publish to docker registry"
           docker buildx build --push \
           --tag ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-          --tag ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+          --tag ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
           -f Dockerfile .
 
       - name: Post build info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-central-1
+          aws-region: us-east-1
 
       - name: Log in to Amazon ECR
         id: login-ecr-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
+          aws-region: eu-central-1
           registry-type: 'public'
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: eu-central-1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
 
       - name: Log in to Amazon ECR
         id: login-ecr-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-central-1
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-access-key-id: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: eu-central-1
 
       - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: 'public'
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
Please not that github.ref_name creates following tags:
![Screenshot from 2024-06-19 16-29-04](https://github.com/emma-community/emma-report-generator/assets/150123473/3468046a-6c5f-44e8-a800-afd289c2cfed)

In case tag name is needed (eg v1.0.0 after the release) it needs to be changed to github.event.release.tag_name I believe